### PR TITLE
Support Fujifilm X-H2S FITS

### DIFF
--- a/src/algos/demosaicing.c
+++ b/src/algos/demosaicing.c
@@ -62,6 +62,13 @@ const char *filter_pattern[] = {
 	"GGBGGR"
 	"GGRGGB",
 
+	"GGBGGR" // ----> XTRANS_3
+	"GGRGGB"
+	"RBGBRG"
+	"GGRGGB"
+	"GGBGGR"
+	"BRGRBG",
+
 	"GRGGBG"
 	"BGBRGR"
 	"GRGGBG"


### PR DESCRIPTION
### Changes
- Support Fujifilm X-H2S CFA pattern.

### Notes
I can't find any documentation from Fujifilm around these patterns, but I've deduced that the R and B channels are in fact inverted compared to the CFA pattern of the Fujifilm X-T3 (which successfully debayers using Siril).

I've confirmed this change with a Fujifilm X-H2S FITS file captured using the Indi Fujifilm drivers.

